### PR TITLE
Fix: NPE if source connector commits record without consumer offsets file.

### DIFF
--- a/src/main/java/de/azapps/kafkabackup/common/offset/OffsetSource.java
+++ b/src/main/java/de/azapps/kafkabackup/common/offset/OffsetSource.java
@@ -47,9 +47,15 @@ public class OffsetSource {
 
     public void syncGroupForOffset(TopicPartition topicPartition, long sourceOffset, long targetOffset) throws IOException {
         OffsetStoreFile offsetStoreFile = topicOffsets.get(topicPartition);
-        // __consumer_offsets contains the offset of the message to read next. So we need to search for the offset + 1
-        // if we do not do that we might miss
-        List<String> groups = offsetStoreFile.groupForOffset(sourceOffset + 1);
+        List<String> groups;
+        if (offsetStoreFile != null) {
+            // __consumer_offsets contains the offset of the message to read next. So we need to search for the offset + 1
+            // if we do not do that we might miss
+            groups = offsetStoreFile.groupForOffset(sourceOffset + 1);
+        } else {
+            // This is normal: if no consumer group was backed up for this topic partition the topicOffsets map returns null.
+            groups = Collections.emptyList();
+        }
         if (groups != null && groups.size() > 0) {
             for (String group : groups) {
                 Map<String, Object> groupConsumerConfig = new HashMap<>(consumerConfig);


### PR DESCRIPTION
Fixes:
```
[2020-02-21 16:44:03,192] ERROR WorkerSourceTask{id=kafka-backup-source-0} Exception thrown while calling task.commitRecord() (org.apache.kafka.connect.runtime.WorkerSourceTask)
java.lang.NullPointerException
	at de.azapps.kafkabackup.common.offset.OffsetSource.syncGroupForOffset(OffsetSource.java:52)
	at de.azapps.kafkabackup.source.BackupSourceTask.commitRecord(BackupSourceTask.java:143)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.commitTaskRecord(WorkerSourceTask.java:393)
	at org.apache.kafka.connect.runtime.WorkerSourceTask.access$300(WorkerSourceTask.java:65)
	at org.apache.kafka.connect.runtime.WorkerSourceTask$1.onCompletion(WorkerSourceTask.java:357)
	at org.apache.kafka.clients.producer.KafkaProducer$InterceptorCallback.onCompletion(KafkaProducer.java:1348)
	at org.apache.kafka.clients.producer.internals.ProducerBatch.completeFutureAndFireCallbacks(ProducerBatch.java:227)
	at org.apache.kafka.clients.producer.internals.ProducerBatch.done(ProducerBatch.java:196)
	at org.apache.kafka.clients.producer.internals.Sender.completeBatch(Sender.java:707)
	at org.apache.kafka.clients.producer.internals.Sender.completeBatch(Sender.java:688)
	at org.apache.kafka.clients.producer.internals.Sender.handleProduceResponse(Sender.java:596)
	at org.apache.kafka.clients.producer.internals.Sender.access$100(Sender.java:74)
	at org.apache.kafka.clients.producer.internals.Sender$1.onComplete(Sender.java:798)
	at org.apache.kafka.clients.ClientResponse.onComplete(ClientResponse.java:109)
	at org.apache.kafka.clients.NetworkClient.completeResponses(NetworkClient.java:562)
	at org.apache.kafka.clients.NetworkClient.poll(NetworkClient.java:554)
	at org.apache.kafka.clients.producer.internals.Sender.runOnce(Sender.java:335)
	at org.apache.kafka.clients.producer.internals.Sender.run(Sender.java:244)
	at java.lang.Thread.run(Thread.java:748)
```