### PR TITLE
Fix: error in record binary format docstring

### DIFF
--- a/src/main/java/de/azapps/kafkabackup/common/record/RecordSerde.java
+++ b/src/main/java/de/azapps/kafkabackup/common/record/RecordSerde.java
@@ -15,8 +15,8 @@ import java.nio.charset.StandardCharsets;
 /**
  * Record Format:
  * offset: int64
- * timestamp: int64
  * timestampType: int32
+ * [timestamp: int64] if timestampType != NO_TIMESTAMP_TYPE
  * keyLength: int32
  * key: byte[keyLength]
  * valueLength: int32


### PR DESCRIPTION
The timestamp type actually comes before the timestamp, and the timestamp is optional, based on the type.