### PR TITLE
OffsetSink refactor

### DIFF
--- a/src/main/java/de/azapps/kafkabackup/common/offset/OffsetSink.java
+++ b/src/main/java/de/azapps/kafkabackup/common/offset/OffsetSink.java
@@ -1,71 +1,113 @@
 package de.azapps.kafkabackup.common.offset;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
+import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.RetriableException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RequiredArgsConstructor
 public abstract class OffsetSink {
 
-  private static final long DEFAULT_SYNC_INTERVAL = 5000;
+    private static final Logger log = LoggerFactory.getLogger(OffsetSink.class);
 
-  private final AdminClient adminClient;
-  private final long syncInterval;
+    private final AdminClient adminClient;
+    private final long consumerGroupsMaxAgeMs;
 
-  private List<String> consumerGroups = new ArrayList<>();
-  private long timeOfLastSync = 0;
+    private Collection<String> consumerGroups = Collections.emptySet();
+    private long consumerGroupsUpdatedAt = 0;
 
-  public OffsetSink(AdminClient adminClient) {
-    this.adminClient = adminClient;
-    this.syncInterval = DEFAULT_SYNC_INTERVAL;
-  }
+    private Collection<TopicPartition> partitions = Collections.emptySet();
+    ReadWriteLock partitionsRWLock = new ReentrantReadWriteLock();
+    Lock partitionsWriteLock = partitionsRWLock.writeLock();
+    Lock partitionsReadLock = partitionsRWLock.readLock();
 
-  public void syncConsumerGroups() {
-    long currentTime = System.currentTimeMillis();
-    if(currentTime - this.timeOfLastSync >= syncInterval) {
-      try {
-        consumerGroups = adminClient.listConsumerGroups()
-            .all().get().stream()
-            .map(ConsumerGroupListing::groupId)
+    private Collection<String> getConsumerGroups() {
+        long currentTime = System.currentTimeMillis();
+        if(currentTime - this.consumerGroupsUpdatedAt > consumerGroupsMaxAgeMs) {
+            try {
+                consumerGroups = adminClient.listConsumerGroups()
+                    .all().get().stream()
+                    .map(ConsumerGroupListing::groupId)
+                    .collect(Collectors.toSet());
+
+                consumerGroupsUpdatedAt = currentTime;
+            } catch (InterruptedException | ExecutionException e) {
+                throw new RetriableException(e);
+            }
+        }
+        return consumerGroups;
+    }
+
+    public void setPartitions(Collection<TopicPartition> partitions) {
+        partitionsWriteLock.lock();
+        try {
+            this.partitions = partitions;
+        } finally {
+            partitionsWriteLock.unlock();
+        }
+    }
+
+    public void syncOffsets() {
+        List<String> listOfExecutionExceptions = getConsumerGroups().stream()
+            .flatMap(consumerGroup -> {
+                try {
+                    syncOffsetsForGroup(consumerGroup);
+                    return Stream.empty();
+                } catch (IOException e) {
+                    return Stream.of(e);
+                }
+            })
+            .map(Throwable::getMessage)
             .collect(Collectors.toList());
-        
-        timeOfLastSync = currentTime;
-      } catch (InterruptedException | ExecutionException e) {
-        throw new RetriableException(e);
-      }
+
+        if (!listOfExecutionExceptions.isEmpty()) {
+            throw new RuntimeException("At least one exception was caught when trying to sync consumer groups offsets: "
+                    + String.join("; ", listOfExecutionExceptions));
+        }
     }
-  }
 
-  public void syncOffsets(Set<TopicPartition> topicPartitions) {
-    List<String> listOfExecutionExceptions = consumerGroups.stream()
-        .flatMap(consumerGroup -> {
-          try {
-            syncOffsetsForGroup(consumerGroup, topicPartitions);
-            return Stream.empty();
-          } catch (IOException e) {
-            return Stream.of(e);
-          }
-        })
-        .map(Throwable::getMessage)
-        .collect(Collectors.toList());
-
-    if(!listOfExecutionExceptions.isEmpty()) {
-      throw new RuntimeException("At least one exception was caught when trying to sync consumer groups offsets: "
-          + String.join("; ", listOfExecutionExceptions));
+    private void syncOffsetsForGroup(String consumerGroup) throws IOException {
+        Map<TopicPartition, OffsetAndMetadata> partitionOffsetsAndMetadata = new HashMap<>();
+        partitionsReadLock.lock();
+        try {
+            // Due to https://issues.apache.org/jira/browse/KAFKA-9507, we need to fetch offsets one TopicPartition at a time
+            // and catch the exception that occurs if the consumer group is missing from the TopicPartition's committed offsets.
+            // TODO: fix when 2.4.1 is released!
+            for (TopicPartition tp : partitions) {
+                ListConsumerGroupOffsetsOptions listConsumerGroupOffsetsOptions = new ListConsumerGroupOffsetsOptions();
+                listConsumerGroupOffsetsOptions.topicPartitions(Collections.singletonList(tp));
+                try {
+                    Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata = adminClient
+                            .listConsumerGroupOffsets(consumerGroup, listConsumerGroupOffsetsOptions)
+                            .partitionsToOffsetAndMetadata()
+                            .get();
+                    partitionOffsetsAndMetadata.put(tp, offsetsAndMetadata.get(tp));
+                } catch (ExecutionException e) {
+                    log.debug("No committed offsets for consumer group {} on topic {} partition {}", consumerGroup, tp.topic(), tp.partition());
+                } catch (InterruptedException e) {
+                    throw new RetriableException(e);
+                }
+            }
+        } finally {
+            partitionsReadLock.unlock();
+        }
+        writeOffsetsForGroup(consumerGroup, partitionOffsetsAndMetadata);
     }
-  }
 
-  public abstract void syncOffsetsForGroup(String consumerGroup, Set<TopicPartition> topicPartition) throws IOException;
-  public abstract void flush();
-  public abstract void close();
-
+    public abstract void writeOffsetsForGroup(String consumerGroup, Map<TopicPartition, OffsetAndMetadata> partitionOffsets) throws IOException;
+    public abstract void flush();
+    public abstract void close();
 }

--- a/src/main/java/de/azapps/kafkabackup/common/offset/OffsetSink.java
+++ b/src/main/java/de/azapps/kafkabackup/common/offset/OffsetSink.java
@@ -9,19 +9,17 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ConsumerGroupListing;
 import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.RetriableException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+@Slf4j
 @RequiredArgsConstructor
 public abstract class OffsetSink {
-
-    private static final Logger log = LoggerFactory.getLogger(OffsetSink.class);
 
     private final AdminClient adminClient;
     private final long consumerGroupsMaxAgeMs;

--- a/src/main/java/de/azapps/kafkabackup/common/offset/S3OffsetSink.java
+++ b/src/main/java/de/azapps/kafkabackup/common/offset/S3OffsetSink.java
@@ -7,8 +7,6 @@ import de.azapps.kafkabackup.storage.s3.AwsS3Service;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.*;
 
 import org.apache.kafka.clients.admin.AdminClient;
@@ -62,10 +60,6 @@ public class S3OffsetSink extends OffsetSink {
 
     private static class OffsetStoreS3File {
         private static final TypeReference<HashMap<String, Long>> groupOffsetsTypeRef = new TypeReference<HashMap<String, Long>>() {};
-        private static final DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd'T'HH");
-        static {
-            dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
-        }
 
         private Map<String, Long> groupOffsets = new HashMap<>();
         private final TopicPartition topicPartition;
@@ -98,8 +92,7 @@ public class S3OffsetSink extends OffsetSink {
         }
 
         private String getOffsetFileName() {
-            String timeStr = dateFormat.format(new Date());
-            return String.format("%s/%03d/offsets_%s.json", topicPartition.topic(), topicPartition.partition(), timeStr);
+            return String.format("%s/%03d/offsets.json", topicPartition.topic(), topicPartition.partition());
         }
     }
 }

--- a/src/main/java/de/azapps/kafkabackup/common/offset/S3OffsetSink.java
+++ b/src/main/java/de/azapps/kafkabackup/common/offset/S3OffsetSink.java
@@ -1,97 +1,77 @@
 package de.azapps.kafkabackup.common.offset;
 
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import de.azapps.kafkabackup.storage.s3.AwsS3Service;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
 import org.apache.kafka.clients.admin.AdminClient;
-import org.apache.kafka.clients.admin.ListConsumerGroupOffsetsOptions;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.connect.errors.RetriableException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class S3OffsetSink extends OffsetSink {
-    private final String bucketName;
-    private final AdminClient adminClient;
     private final AwsS3Service awsS3Service;
-    private static final Logger log = LoggerFactory.getLogger(OffsetSink.class);
+    private final String bucketName;
 
     private Map<TopicPartition, OffsetStoreS3File> topicOffsets = new HashMap<>();
 
     public S3OffsetSink(
         AdminClient adminClient,
-        String bucketName,
+        Long consumerGroupsSyncInterval,
         AwsS3Service awsS3Service,
-        Long consumerGroupsSyncInterval
+        String bucketName
     ) {
         super(adminClient, consumerGroupsSyncInterval);
-        this.bucketName = bucketName;
-        this.adminClient = adminClient;
         this.awsS3Service = awsS3Service;
+        this.bucketName = bucketName;
     }
 
-    public void syncOffsetsForGroup(String consumerGroup, Set<TopicPartition> topicPartitions) throws IOException {
-        Map<TopicPartition, OffsetAndMetadata> topicOffsetsAndMetadata = new HashMap<>();
-        // Due to https://issues.apache.org/jira/browse/KAFKA-9507, we need to fetch offsets one TopicPartition at a time
-        // and catch the exception that occurs if the consumer group is missing from the TopicPartition's committed offsets.
-        // TODO: fix when 2.4.1 is released!
-        for (TopicPartition tp: topicPartitions) {
-            ListConsumerGroupOffsetsOptions listConsumerGroupOffsetsOptions = new ListConsumerGroupOffsetsOptions();
-            listConsumerGroupOffsetsOptions.topicPartitions(Collections.singletonList(tp));
-            try {
-                Map<TopicPartition, OffsetAndMetadata> offsetsAndMetadata = adminClient
-                    .listConsumerGroupOffsets(consumerGroup, listConsumerGroupOffsetsOptions)
-                    .partitionsToOffsetAndMetadata()
-                    .get();
-                topicOffsetsAndMetadata.put(tp, offsetsAndMetadata.get(tp));
-            } catch (ExecutionException e) {
-                log.debug("No committed offsets for consumer group {} on topic {} partition {}", consumerGroup, tp.topic(), tp.partition());
-            } catch (InterruptedException e) {
-                throw new RetriableException(e);
-            }
-        }
-
-        for (TopicPartition tp : topicOffsetsAndMetadata.keySet()) {
+    @Override
+    public void writeOffsetsForGroup(String consumerGroup, Map<TopicPartition, OffsetAndMetadata> partitionOffsetsAndMetadata) throws IOException {
+        for (TopicPartition tp : partitionOffsetsAndMetadata.keySet()) {
             if (!this.topicOffsets.containsKey(tp)) {
                 this.topicOffsets.put(tp, new OffsetStoreS3File(tp, bucketName, awsS3Service));
             }
 
             OffsetStoreS3File offsets = this.topicOffsets.get(tp);
-            offsets.put(consumerGroup, topicOffsetsAndMetadata.get(tp).offset());
+            offsets.put(consumerGroup, partitionOffsetsAndMetadata.get(tp).offset());
         }
     }
 
+    @Override
     public void flush() {
-    for (OffsetStoreS3File offsetStoreFile : topicOffsets.values()) {
-        try {
-            offsetStoreFile.flush();
-        } catch (IOException e) {
-            throw new RuntimeException("Unable to flush offset store file");
+        for (OffsetStoreS3File offsetStoreFile : topicOffsets.values()) {
+            try {
+                offsetStoreFile.flush();
+            } catch (IOException e) {
+                throw new RuntimeException("Unable to flush offset store file");
+            }
         }
     }
-    }
 
+    @Override
     public void close() {
-
+        flush();
     }
 
     private static class OffsetStoreS3File {
+        private static final TypeReference<HashMap<String, Long>> groupOffsetsTypeRef = new TypeReference<HashMap<String, Long>>() {};
+        private static final DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd'T'HH");
+        static {
+            dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+        }
+
         private Map<String, Long> groupOffsets = new HashMap<>();
         private final TopicPartition topicPartition;
         private final String bucketName;
-
-
-        private ObjectMapper mapper = new ObjectMapper();
-        private AwsS3Service awsS3Service;
+        private final ObjectMapper mapper = new ObjectMapper();
+        private final AwsS3Service awsS3Service;
 
         OffsetStoreS3File(TopicPartition topicPartition, String bucketName, AwsS3Service awsS3Service) throws IOException {
             this.bucketName = bucketName;
@@ -99,7 +79,7 @@ public class S3OffsetSink extends OffsetSink {
             this.awsS3Service = awsS3Service;
 
             if (awsS3Service.checkIfObjectExists(bucketName, getOffsetFileName())) {
-                groupOffsets = mapper.readValue(awsS3Service.getFile(bucketName, getOffsetFileName()).getObjectContent(), Map.class);
+                groupOffsets = mapper.readValue(awsS3Service.getFile(bucketName, getOffsetFileName()).getObjectContent(), groupOffsetsTypeRef);
             }
         }
 
@@ -118,7 +98,8 @@ public class S3OffsetSink extends OffsetSink {
         }
 
         private String getOffsetFileName() {
-            return String.format("%s/%03d/offsets.json", topicPartition.topic(), topicPartition.partition());
+            String timeStr = dateFormat.format(new Date());
+            return String.format("%s/%03d/offsets_%s.json", topicPartition.topic(), topicPartition.partition(), timeStr);
         }
     }
 }


### PR DESCRIPTION
No new functionality, only refactoring:

- general whitespace fixes / naming changes etc. 😇
- move all admin client work to abstract OffsetSink base class. `syncOffsetsForGroup` is split into `syncOffsetsForGroup` and `writeOffsetsForGroup`
- store current partitions in OffsetSink, so that syncOffsets() needs to arguments. This is to prepare for scheduling in a follow up PR.

How to test:
- [x] unit tests still pass
- [x] dreams2-connect integration tests still pass