### PR TITLE
Batch

### DIFF
--- a/src/main/java/de/azapps/kafkabackup/common/partition/PartitionWriter.java
+++ b/src/main/java/de/azapps/kafkabackup/common/partition/PartitionWriter.java
@@ -8,4 +8,5 @@ public interface PartitionWriter {
     void flush() throws PartitionException;
     String topic();
     int partition();
+    Long getLastCommittableOffset();
 }

--- a/src/main/java/de/azapps/kafkabackup/common/partition/PartitionWriter.java
+++ b/src/main/java/de/azapps/kafkabackup/common/partition/PartitionWriter.java
@@ -6,7 +6,6 @@ public interface PartitionWriter {
     void append(Record record) throws PartitionException;
     void close() throws PartitionException;
     void flush() throws PartitionException;
-    long lastWrittenOffset();
     String topic();
     int partition();
 }

--- a/src/main/java/de/azapps/kafkabackup/common/partition/cloud/S3BatchWriter.java
+++ b/src/main/java/de/azapps/kafkabackup/common/partition/cloud/S3BatchWriter.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import de.azapps.kafkabackup.common.record.Record;
 import de.azapps.kafkabackup.common.record.RecordJSONSerde;
 import de.azapps.kafkabackup.storage.s3.AwsS3Service;
+import lombok.Getter;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.RetriableException;
 
@@ -13,7 +14,8 @@ import java.io.IOException;
 
 public class S3BatchWriter {
 
-    private static final byte[] RECORD_SEPARATOR = {0x0A};  // utf-8 encoding of unix line feed
+    private static final byte UTF8_UNIX_LINE_FEED = 0x0A;
+    private static final byte[] RECORD_SEPARATOR = {UTF8_UNIX_LINE_FEED};
 
     private final AwsS3Service awsS3Service;
     private final String bucketName;
@@ -24,9 +26,13 @@ public class S3BatchWriter {
     private final RecordJSONSerde recordJSONSerde = new RecordJSONSerde();
     private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
+    @Getter
     private long startWallClockTime;
+    @Getter
     private long startOffset;
+    @Getter
     private long endOffset;
+    @Getter
     private long count = 0;
 
     public S3BatchWriter(AwsS3Service awsS3Service, String bucketName, TopicPartition tp, Record record) throws IOException {
@@ -63,21 +69,5 @@ public class S3BatchWriter {
 
     public String getObjectKey() {
         return String.format("%s/%03d/msg_%020d.json", topic, partition, startOffset);
-    }
-
-    public long getStartOffset() {
-        return startOffset;
-    }
-
-    public long getEndOffset() {
-        return endOffset;
-    }
-
-    public long getStartWallClockTime() {
-        return startWallClockTime;
-    }
-
-    public long getCount() {
-        return count;
     }
 }

--- a/src/main/java/de/azapps/kafkabackup/common/partition/cloud/S3BatchWriter.java
+++ b/src/main/java/de/azapps/kafkabackup/common/partition/cloud/S3BatchWriter.java
@@ -1,0 +1,83 @@
+package de.azapps.kafkabackup.common.partition.cloud;
+
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import de.azapps.kafkabackup.common.record.Record;
+import de.azapps.kafkabackup.common.record.RecordJSONSerde;
+import de.azapps.kafkabackup.storage.s3.AwsS3Service;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.RetriableException;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+public class S3BatchWriter {
+
+    private static final byte[] RECORD_SEPARATOR = {0x0A};  // utf-8 encoding of unix line feed
+
+    private final AwsS3Service awsS3Service;
+    private final String bucketName;
+
+    private final String topic;
+    private final int partition;
+
+    private final RecordJSONSerde recordJSONSerde = new RecordJSONSerde();
+    private final ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+
+    private long startWallClockTime;
+    private long startOffset;
+    private long endOffset;
+    private long count = 0;
+
+    public S3BatchWriter(AwsS3Service awsS3Service, String bucketName, TopicPartition tp, Record record) throws IOException {
+        this.awsS3Service = awsS3Service;
+        this.bucketName = bucketName;
+        this.topic = tp.topic();
+        this.partition = tp.partition();
+        // Initialize S3BatchWriter with a first record
+        this.startWallClockTime = System.currentTimeMillis();
+        this.startOffset = record.kafkaOffset();
+        append(record);
+    }
+
+    public void append(Record record) throws IOException {
+        recordJSONSerde.write(buffer, record);
+        buffer.write(RECORD_SEPARATOR);
+        endOffset = record.kafkaOffset();
+        count++;
+    }
+
+    public void commitBatch() throws RetriableException {
+        // Assume that we can store all content in memory at once
+        // TODO: upgrade to >= Java 9 and use InputStream.transferTo() ?
+        byte[] batchContent = buffer.toByteArray();
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(batchContent);
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(batchContent.length);
+        try {
+            awsS3Service.saveFile(bucketName, getObjectKey(), inputStream, objectMetadata);
+        } catch (RuntimeException e) {
+            throw new RetriableException(e);
+        }
+    }
+
+    public String getObjectKey() {
+        return String.format("%s/%03d/msg_%020d.json", topic, partition, startOffset);
+    }
+
+    public long getStartOffset() {
+        return startOffset;
+    }
+
+    public long getEndOffset() {
+        return endOffset;
+    }
+
+    public long getStartWallClockTime() {
+        return startWallClockTime;
+    }
+
+    public long getCount() {
+        return count;
+    }
+}

--- a/src/main/java/de/azapps/kafkabackup/common/partition/cloud/S3PartitionWriter.java
+++ b/src/main/java/de/azapps/kafkabackup/common/partition/cloud/S3PartitionWriter.java
@@ -63,6 +63,7 @@ public class S3PartitionWriter implements PartitionWriter {
 
   private void maybeCommitBasedOnMessages() {
     if (batchWriter != null && batchWriter.getCount() >= maxBatchMessages) {
+      log.info("Commit {} based on num messages", batchWriter.getObjectKey());
       commitCurrentBatch();
     }
   }
@@ -70,6 +71,7 @@ public class S3PartitionWriter implements PartitionWriter {
   private void maybeCommitBasedOnTime() {
     long now = System.currentTimeMillis();
     if (batchWriter != null && (now - batchWriter.getStartWallClockTime()) >= maxBatchTimeMs) {
+      log.info("Commit {} based on time", batchWriter.getObjectKey());
       commitCurrentBatch();
     }
   }

--- a/src/main/java/de/azapps/kafkabackup/common/partition/cloud/S3PartitionWriter.java
+++ b/src/main/java/de/azapps/kafkabackup/common/partition/cloud/S3PartitionWriter.java
@@ -4,6 +4,7 @@ import de.azapps.kafkabackup.common.partition.PartitionException;
 import de.azapps.kafkabackup.common.partition.PartitionWriter;
 import de.azapps.kafkabackup.common.record.Record;
 import de.azapps.kafkabackup.storage.s3.AwsS3Service;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.RetriableException;
@@ -13,6 +14,7 @@ import java.util.LinkedList;
 import java.util.Queue;
 
 @Slf4j
+@RequiredArgsConstructor
 public class S3PartitionWriter implements PartitionWriter {
 
   private final AwsS3Service awsS3Service;
@@ -24,15 +26,6 @@ public class S3PartitionWriter implements PartitionWriter {
 
   private S3BatchWriter batchWriter;
   private Long lastCommittableOffset = null; // Nothing written so far, so nothing to commit
-
-
-  public S3PartitionWriter(AwsS3Service awsS3Service, String bucketName, TopicPartition tp, int maxBatchMessages, long maxBatchTimeMs) {
-    this.awsS3Service = awsS3Service;
-    this.bucketName = bucketName;
-    this.topicPartition = tp;
-    this.maxBatchMessages = maxBatchMessages;
-    this.maxBatchTimeMs = maxBatchTimeMs;
-  }
 
   @Override
   public void append(Record record) throws PartitionException {

--- a/src/main/java/de/azapps/kafkabackup/common/partition/cloud/S3PartitionWriter.java
+++ b/src/main/java/de/azapps/kafkabackup/common/partition/cloud/S3PartitionWriter.java
@@ -24,9 +24,6 @@ public class S3PartitionWriter implements PartitionWriter {
 
   private final RecordJSONSerde recordJSONSerde = new RecordJSONSerde();
 
-  private final long lastWrittenOffset = 0;
-
-
   @Override
   public void append(Record record) throws PartitionException {
     String fileName = buildFileKeyForRecord(topicName, partition, record);
@@ -57,11 +54,6 @@ public class S3PartitionWriter implements PartitionWriter {
   @Override
   public void flush() throws PartitionException {
 
-  }
-
-  @Override
-  public long lastWrittenOffset() {
-    return lastWrittenOffset;
   }
 
   @Override

--- a/src/main/java/de/azapps/kafkabackup/common/partition/disk/DiskPartitionWriter.java
+++ b/src/main/java/de/azapps/kafkabackup/common/partition/disk/DiskPartitionWriter.java
@@ -96,6 +96,11 @@ public class DiskPartitionWriter implements PartitionWriter {
 
     @Override
     public Long getLastCommittableOffset() {
-        return lastWrittenOffset() + 1; // committed offset in kafka are the *next to read*.
+        long offset = lastWrittenOffset();
+        if (offset < 0) {
+            return null;
+        } else {
+            return offset + 1;// committed offset in kafka are the *next to read*.
+        }
     }
 }

--- a/src/main/java/de/azapps/kafkabackup/common/partition/disk/DiskPartitionWriter.java
+++ b/src/main/java/de/azapps/kafkabackup/common/partition/disk/DiskPartitionWriter.java
@@ -52,6 +52,7 @@ public class DiskPartitionWriter implements PartitionWriter {
         return currentSegment.lastWrittenOffset();
     }
 
+    @Override
     public void append(Record record) throws PartitionException {
         try {
             if (currentSegment.size() > maxSegmentSize) {
@@ -63,6 +64,7 @@ public class DiskPartitionWriter implements PartitionWriter {
         }
     }
 
+    @Override
     public void close() throws PartitionException {
         try {
             partitionIndex.close();
@@ -72,6 +74,7 @@ public class DiskPartitionWriter implements PartitionWriter {
         }
     }
 
+    @Override
     public void flush() throws PartitionException {
         try {
             partitionIndex.flush();
@@ -81,10 +84,12 @@ public class DiskPartitionWriter implements PartitionWriter {
         }
     }
 
+    @Override
     public String topic() {
         return topic;
     }
 
+    @Override
     public int partition() {
         return partition;
     }

--- a/src/main/java/de/azapps/kafkabackup/common/partition/disk/DiskPartitionWriter.java
+++ b/src/main/java/de/azapps/kafkabackup/common/partition/disk/DiskPartitionWriter.java
@@ -93,4 +93,9 @@ public class DiskPartitionWriter implements PartitionWriter {
     public int partition() {
         return partition;
     }
+
+    @Override
+    public Long getLastCommittableOffset() {
+        return lastWrittenOffset() + 1; // committed offset in kafka are the *next to read*.
+    }
 }

--- a/src/main/java/de/azapps/kafkabackup/sink/BackupSinkConfig.java
+++ b/src/main/java/de/azapps/kafkabackup/sink/BackupSinkConfig.java
@@ -4,7 +4,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigDef.Type;
 
 class BackupSinkConfig extends AbstractConfig {
     // Standard Kafka Connect Task configs
@@ -26,6 +25,8 @@ class BackupSinkConfig extends AbstractConfig {
     static final String STORAGE_MODE = "storage.mode";
     static final String CONSUMER_GROUPS_SYNC_MAX_AGE_MS = "consumer.groups.sync.max.age.ms";
     static final String CONSUMER_OFFSET_SYNC_INTERVAL_MS = "consumer.offset.sync.interval.ms";
+    static final String MAX_BATCH_MESSAGES = "max.batch.messages";
+    static final String MAX_BATCH_TIME_MS = "max.batch.time.ms";
 
     static final ConfigDef CONFIG_DEF = new ConfigDef()
             .define(KEY_CONVERTER, ConfigDef.Type.STRING, KAFKA_BYTE_ARRAY_CONVERTER_CLASS,
@@ -48,10 +49,14 @@ class BackupSinkConfig extends AbstractConfig {
                     ConfigDef.Importance.MEDIUM, "AWS S3 Bucket path style access")
             .define(AWS_S3_BUCKET_NAME, ConfigDef.Type.STRING,
                     ConfigDef.Importance.MEDIUM, "AWS S3 Bucket name")
-            .define(CONSUMER_GROUPS_SYNC_MAX_AGE_MS, Type.LONG, 300000,
+            .define(CONSUMER_GROUPS_SYNC_MAX_AGE_MS, ConfigDef.Type.LONG, 300000,
                     ConfigDef.Importance.MEDIUM, "List of consumer groups for offset sync will be an most this old.")
-            .define(CONSUMER_OFFSET_SYNC_INTERVAL_MS, Type.LONG, 60000,
-                    ConfigDef.Importance.MEDIUM, "Consumer offsets will be synced at this interval.");
+            .define(CONSUMER_OFFSET_SYNC_INTERVAL_MS, ConfigDef.Type.LONG, 60000,
+                    ConfigDef.Importance.MEDIUM, "Consumer offsets will be synced at this interval.")
+            .define(MAX_BATCH_MESSAGES, ConfigDef.Type.INT, 1000,
+                    ConfigDef.Importance.MEDIUM, "Batches will be rotated after this number of messages.")
+            .define(MAX_BATCH_TIME_MS, ConfigDef.Type.LONG, 600000,
+                    ConfigDef.Importance.MEDIUM, "Batches will be rotated after this amount of time.");
 
     BackupSinkConfig(Map<?, ?> props) {
         super(CONFIG_DEF, props);
@@ -116,4 +121,6 @@ class BackupSinkConfig extends AbstractConfig {
     Long consumerOffsetSyncIntervalMs() {
         return getLong(CONSUMER_OFFSET_SYNC_INTERVAL_MS);
     }
+    Integer maxBatchMessages() { return getInt(MAX_BATCH_MESSAGES); }
+    Long maxBatchTimeMs() { return getLong(MAX_BATCH_TIME_MS); }
 }

--- a/src/main/java/de/azapps/kafkabackup/sink/BackupSinkTask.java
+++ b/src/main/java/de/azapps/kafkabackup/sink/BackupSinkTask.java
@@ -97,6 +97,7 @@ public class BackupSinkTask extends SinkTask {
         try {
             records.forEach(sinkRecord -> {
                 TopicPartition topicPartition = new TopicPartition(sinkRecord.topic(), sinkRecord.kafkaPartition());
+                log.info("Put {} : {}", topicPartition, sinkRecord.kafkaOffset());
                 PartitionWriter partition = partitionWriters.get(topicPartition);
                 Record record = Record.fromSinkRecord(sinkRecord);
                 partition.append(record);
@@ -119,6 +120,7 @@ public class BackupSinkTask extends SinkTask {
     }
 
     private void openPartition(TopicPartition tp) {
+        log.info("Open partition {}", tp);
         PartitionWriter partitionWriter = newPartitionWriter(tp);
         partitionWriters.put(tp, partitionWriter);
         switch(storageMode) {
@@ -194,6 +196,7 @@ public class BackupSinkTask extends SinkTask {
         // Note: we must iterate over all assigned partitions here,
         // since time-based rotation might kick in for partitions not present in last call to put().
         for (TopicPartition tp : partitionWriters.keySet()) {
+            log.info("Flushing {}", tp);
             PartitionWriter partitionWriter = partitionWriters.get(tp);
             try {
                 partitionWriter.flush(); // Trigger a flush for this partition
@@ -221,7 +224,7 @@ public class BackupSinkTask extends SinkTask {
             Long committableOffset = partitionWriters.get(tp).getLastCommittableOffset();
             if (committableOffset != null) {
                 // Only commit offsets that where successfully written to target
-                log.trace("Mark {} : {} as ready to commit.", tp, committableOffset);
+                log.info("Mark {} : {} as ready to commit.", tp, committableOffset);
                 offsetsToCommit.put(tp, new OffsetAndMetadata(committableOffset));
             }
         }

--- a/src/main/java/de/azapps/kafkabackup/sink/BackupSinkTask.java
+++ b/src/main/java/de/azapps/kafkabackup/sink/BackupSinkTask.java
@@ -15,6 +15,7 @@ import de.azapps.kafkabackup.storage.s3.AwsS3Service;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
@@ -29,15 +30,23 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class BackupSinkTask extends SinkTask {
+
+    private static final Long MIN_TIMEOUT_MS = 200L;
     private static final Logger log = LoggerFactory.getLogger(BackupSinkTask.class);
-    private Path targetDir;
-    private String bucketName;
+
     private Map<TopicPartition, PartitionWriter> partitionWriters = new HashMap<>();
-    private long maxSegmentSize;
     private OffsetSink offsetSink;
     private OffsetSinkScheduler offsetSinkScheduler;
     private StorageMode storageMode;
+    // DISK-specific:
+    private Path targetDir;
+    private long maxSegmentSize;
+    // S3-specific:
+    private String bucketName;
     private AwsS3Service awsS3Service;
+    private int maxBatchMessages;
+    private long maxBatchTimeMs;
+    private long timeoutMs = MIN_TIMEOUT_MS;
 
     @Override
     public String version() {
@@ -58,6 +67,8 @@ public class BackupSinkTask extends SinkTask {
                 awsS3Service = new AwsS3Service(config.region(), config.endpoint(), config.pathStyleAccessEnabled());
                 bucketName = config.bucketName();
                 offsetSink = new S3OffsetSink(adminClient, config.consumerGroupsSyncMaxAgeMs(), awsS3Service, bucketName);
+                maxBatchMessages = config.maxBatchMessages();
+                maxBatchTimeMs = config.maxBatchTimeMs();
                 break;
             case DISK:
                 targetDir = Paths.get(config.targetDir());
@@ -85,16 +96,10 @@ public class BackupSinkTask extends SinkTask {
     public void put(Collection<SinkRecord> records) {
         try {
             records.forEach(sinkRecord -> {
-                log.info("SinkRecord: {}", sinkRecord);
                 TopicPartition topicPartition = new TopicPartition(sinkRecord.topic(), sinkRecord.kafkaPartition());
                 PartitionWriter partition = partitionWriters.get(topicPartition);
                 Record record = Record.fromSinkRecord(sinkRecord);
-                log.info("Record: {}", record);
                 partition.append(record);
-                if (sinkRecord.kafkaOffset() % 100 == 0) {
-                    log.debug("Backed up Topic {}, Partition {}, up to offset {}", sinkRecord.topic(),
-                            sinkRecord.kafkaPartition(), sinkRecord.kafkaOffset());
-                }
             });
         } catch (PartitionException e) {
             throw new RuntimeException(e);
@@ -104,61 +109,58 @@ public class BackupSinkTask extends SinkTask {
     @Override
     public void open(Collection<TopicPartition> partitions) {
         super.open(partitions);
-        try {
-            for (TopicPartition topicPartition : partitions) {
-                PartitionWriter partitionWriter;
-                switch (storageMode) {
-                    case DISK:
-                        partitionWriter = openDiskPartition(topicPartition);
-                        break;
-                    case S3:
-                        partitionWriter = openS3Partition(topicPartition);
-                        break;
-                    default:
-                        throw new RuntimeException(String.format("Invalid Storage Mode. Supported values are %s or %s", StorageMode.DISK, StorageMode.S3));
+        if (partitions.isEmpty()) {
+            log.info("No partitions assigned to BackupSinkTask");
+        }
+        for (TopicPartition topicPartition : partitions) {
+            openPartition(topicPartition);
+        }
+        offsetSink.setPartitions(partitionWriters.keySet());
+    }
+
+    private void openPartition(TopicPartition tp) {
+        PartitionWriter partitionWriter = newPartitionWriter(tp);
+        partitionWriters.put(tp, partitionWriter);
+        switch(storageMode) {
+            case DISK:
+                Long offset = partitionWriter.getLastCommittableOffset();
+                // In the DISK storage mode, we track our own offsets in the target data.
+                // Note that we must *always* request that we seek to an offset here. Currently the
+                // framework will still commit Kafka offsets even though we track our own (see KAFKA-3462),
+                // which can result in accidentally using that offset if one was committed but no files
+                // were written to disk. To protect against this, even if we
+                // just want to start at offset 0 or reset to the earliest offset, we specify that
+                // explicitly to forcibly override any committed offsets.
+                if (offset != null) {
+                    context.offset(tp, offset);
+                    log.debug("Initialized Topic {}, Partition {}. Offset {}", tp.topic(), tp.partition(), offset);
+                } else {
+                    // The offset was not found, so rather than forcibly set the offset to 0 we let the
+                    // consumer decide where to start based upon standard consumer offsets (if available)
+                    // or the consumer's `auto.offset.reset` configuration
+                    log.info("Resetting offset for {} based upon existing consumer group offsets or, if "
+                            + "there are none, the consumer's 'auto.offset.reset' value.", tp);
                 }
-                this.partitionWriters.put(topicPartition, partitionWriter);
-            }
-            if (partitions.isEmpty()) {
-                log.info("No partitions assigned to BackupSinkTask");
-            }
-            offsetSink.setPartitions(partitionWriters.keySet());
-        } catch (IOException | SegmentIndex.IndexException | PartitionIndex.IndexException e) {
-            throw new RuntimeException(e);
+            default:
+                // In the S3 storage mode, we let kafka take care of offsets. So no call to context.offset here.
         }
     }
 
-    private PartitionWriter openDiskPartition(TopicPartition tp) throws IOException, SegmentIndex.IndexException, PartitionIndex.IndexException {
-        Path topicDir = Paths.get(targetDir.toString(), tp.topic());
-        Files.createDirectories(topicDir);
-        DiskPartitionWriter partitionWriter = new DiskPartitionWriter(tp.topic(), tp.partition(), topicDir, maxSegmentSize);
-        long lastWrittenOffset = partitionWriter.lastWrittenOffset();
-        // In the DISK storage mode, we track our own offsets in the target data.
-        // Note that we must *always* request that we seek to an offset here. Currently the
-        // framework will still commit Kafka offsets even though we track our own (see KAFKA-3462),
-        // which can result in accidentally using that offset if one was committed but no files
-        // were written to disk. To protect against this, even if we
-        // just want to start at offset 0 or reset to the earliest offset, we specify that
-        // explicitly to forcibly override any committed offsets.
-        if (lastWrittenOffset > 0) {
-            context.offset(tp, lastWrittenOffset + 1);
-            log.debug("Initialized Topic {}, Partition {}. Last written offset: {}"
-                    , tp.topic(), tp.partition(), lastWrittenOffset);
-        } else {
-            // The offset was not found, so rather than forcibly set the offset to 0 we let the
-            // consumer decide where to start based upon standard consumer offsets (if available)
-            // or the consumer's `auto.offset.reset` configuration
-            log.info("Resetting offset for {} based upon existing consumer group offsets or, if "
-                    + "there are none, the consumer's 'auto.offset.reset' value.", tp);
+    private PartitionWriter newPartitionWriter(TopicPartition tp) {
+        switch (storageMode) {
+            case DISK:
+                try {
+                    Path topicDir = Paths.get(targetDir.toString(), tp.topic());
+                    Files.createDirectories(topicDir);
+                    return new DiskPartitionWriter(tp.topic(), tp.partition(), topicDir, maxSegmentSize);
+                } catch (IOException | SegmentIndex.IndexException | PartitionIndex.IndexException e) {
+                    throw new RuntimeException(e);
+                }
+            case S3:
+                return new S3PartitionWriter(awsS3Service, bucketName, tp, maxBatchMessages, maxBatchTimeMs);
+            default:
+                throw new RuntimeException(String.format("Invalid Storage Mode. Supported values are %s or %s", StorageMode.DISK, StorageMode.S3));
         }
-        return partitionWriter;
-    }
-
-    private PartitionWriter openS3Partition(TopicPartition tp) {
-        return new S3PartitionWriter(awsS3Service, bucketName, tp);
-        // In the S3 storage mode, we track offsets in the source kafka cluster (due to eventual consistency)
-        // See approach described in https://www.confluent.io/blog/apache-kafka-to-amazon-s3-exactly-once/
-        // So no call to context.offset here.
     }
 
     public void close(Collection<TopicPartition> partitions) {
@@ -185,37 +187,45 @@ public class BackupSinkTask extends SinkTask {
 
     @Override
     public void flush(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
-        for (PartitionWriter partitionWriter : partitionWriters.values()) {
-            partitionWriter.flush();
-            log.debug("Flushed Topic {}, Partition {}"
-                    , partitionWriter.topic(), partitionWriter.partition());
+        flush();
+    }
+
+    public void flush() {
+        // Note: we must iterate over all assigned partitions here,
+        // since time-based rotation might kick in for partitions not present in last call to put().
+        for (TopicPartition tp : partitionWriters.keySet()) {
+            PartitionWriter partitionWriter = partitionWriters.get(tp);
+            try {
+                partitionWriter.flush(); // Trigger a flush for this partition
+                timeoutMs = MIN_TIMEOUT_MS; // Reset timeout on success
+            } catch (RetriableException e) {
+                // Reset connector to lastCommittableOffset (if any)
+                Long resetOffset = partitionWriter.getLastCommittableOffset();
+                if (resetOffset != null) {
+                    context.offset(tp, resetOffset);
+                }
+                // And request a retry in at most timeoutMs
+                context.timeout(timeoutMs);
+                timeoutMs *= 2; // backoff exponentially
+                // And completely reset the partition writer
+                partitionWriters.put(tp, newPartitionWriter(tp));
+            }
         }
     }
 
     @Override
     public Map<TopicPartition, OffsetAndMetadata> preCommit(Map<TopicPartition, OffsetAndMetadata> currentOffsets) {
-        switch (storageMode) {
-            case DISK:
-                // Flush to disk and then return null to prevent offsets from being committed in source cluster
-                flush(currentOffsets);
-                return null;
-            case S3:
-                // Only commit offsets that where successfully written to S3
-                Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = new HashMap<>();
-                // Note: we must iterate over all assigned partitions here,
-                // since time-based rotation might have kicked in for partitions not present in last call to put().
-                for (TopicPartition tp : partitionWriters.keySet()) {
-                    Long offset = partitionWriters.get(tp).getLastCommittableOffset(); // this is already last written + 1
-                    if (offset != null) {
-                        log.trace("Mark {} : {} as ready to commit.", tp, offset);
-                        offsetsToCommit.put(tp, new OffsetAndMetadata(offset));
-                    }
-                }
-                return offsetsToCommit;
-            default:
-                // This shouldn't happen, but still:
-                flush(currentOffsets);
-                return currentOffsets;
+        flush(currentOffsets);
+        Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = new HashMap<>();
+        for (TopicPartition tp : partitionWriters.keySet()) {
+            Long committableOffset = partitionWriters.get(tp).getLastCommittableOffset();
+            if (committableOffset != null) {
+                // Only commit offsets that where successfully written to target
+                log.trace("Mark {} : {} as ready to commit.", tp, committableOffset);
+                offsetsToCommit.put(tp, new OffsetAndMetadata(committableOffset));
+            }
         }
+        // TODO: return null for DISK storage mode?
+        return offsetsToCommit;
     }
 }

--- a/src/main/java/de/azapps/kafkabackup/sink/BackupSinkTask.java
+++ b/src/main/java/de/azapps/kafkabackup/sink/BackupSinkTask.java
@@ -202,6 +202,7 @@ public class BackupSinkTask extends SinkTask {
                 partitionWriter.flush(); // Trigger a flush for this partition
                 timeoutMs = MIN_TIMEOUT_MS; // Reset timeout on success
             } catch (RetriableException e) {
+                log.warn("Retriable exception when flushing {} : {}", tp, e.getMessage());
                 // Reset connector to lastCommittableOffset (if any)
                 Long resetOffset = partitionWriter.getLastCommittableOffset();
                 if (resetOffset != null) {


### PR DESCRIPTION
Kafka messages will be written in batches to S3 instead of one message per object.
Two new settings control this behaviour:

- `max.batch.messages`, when a batch contains this number of messages, the object will be written and a new batch started
- `max.batch.time.ms`, a batch will be rotated after this time, whether its full or not.

Note that all writing to S3 is done in the `pre-commit` hook, which means that it will only be performed every `offset.flush.interval.ms` (default 60000).

The behaviour is tested by this branch of dreams2-connect: https://github.com/getdreams/dreams2-connect/pull/17