### PR TITLE
use CONNECT_ADMIN_ envvars to pre-populate custom AdminClient config

### DIFF
--- a/src/main/java/de/azapps/kafkabackup/sink/BackupSinkConfig.java
+++ b/src/main/java/de/azapps/kafkabackup/sink/BackupSinkConfig.java
@@ -80,8 +80,24 @@ class BackupSinkConfig extends AbstractConfig {
 
     Map<String, Object> adminConfig() {
         Map<String, Object> props = new HashMap<>();
+        // First use envvars to populate certain props
+        String saslMechanism = System.getenv("CONNECT_ADMIN_SASL_MECHANISM");
+        if (saslMechanism != null) {
+            props.put("sasl.mechanism", saslMechanism);
+        }
+        String securityProtocol = System.getenv("CONNECT_ADMIN_SECURITY_PROTOCOL");
+        if (securityProtocol != null) {
+            props.put("security.protocol", securityProtocol);
+        }
+        // NOTE: this is secret, so we *cannot* put it in the task config
+        String saslJaasConfig = System.getenv("CONNECT_ADMIN_SASL_JAAS_CONFIG");
+        if (saslJaasConfig != null) {
+            props.put("sasl.jaas.config", saslJaasConfig);
+        }
+        // Then override with task config
         props.putAll(originalsWithPrefix(CLUSTER_PREFIX));
         props.putAll(originalsWithPrefix(ADMIN_CLIENT_PREFIX));
+
         return props;
     }
 


### PR DESCRIPTION
In order to connect to kafka through SASL, it was not enough to specify the env vars for the connect task (see https://github.com/getdreams/dreams-iac/blob/master/manifests/dreams2/production/eu-central-1/ecs-services/connect/service/terragrunt.hcl)

We are abusing the connect framework a bit by creating our own AdminClient for reading consumer group offsets. This is configured through the task config, but we cannot put secrets there. Thus, we now read the `CONNECT_ADMIN_` envvars directly when configuring the AdminClient.