### PR TITLE
Tc-73/scheduler bug fix

### DIFF
--- a/src/main/java/de/azapps/kafkabackup/common/offset/OffsetSink.java
+++ b/src/main/java/de/azapps/kafkabackup/common/offset/OffsetSink.java
@@ -64,7 +64,7 @@ public abstract class OffsetSink {
                 try {
                     syncOffsetsForGroup(consumerGroup);
                     return Stream.empty();
-                } catch (IOException e) {
+                } catch (Exception e) {
                     return Stream.of(e);
                 }
             })

--- a/src/main/java/de/azapps/kafkabackup/common/offset/OffsetSinkScheduler.java
+++ b/src/main/java/de/azapps/kafkabackup/common/offset/OffsetSinkScheduler.java
@@ -21,10 +21,15 @@ public class OffsetSinkScheduler {
     public void start(long syncIntervalMs) {
         log.info("Started OffsetSinkScheduler");
         final Runnable task = () -> {
-            log.info("Syncing offsets...");
-            offsetSink.syncOffsets();
-            offsetSink.flush();
-            log.info("Syncing offsets... done");
+            try {
+                log.info("Syncing offsets...");
+                offsetSink.syncOffsets();
+                offsetSink.flush();
+                log.info("Syncing offsets... done");
+            }
+            catch (Throwable throwable) {
+                log.error("Error occurred while syncing offsets.", throwable);
+            }
         };
         handle = executorService.scheduleAtFixedRate(task, 0, syncIntervalMs, TimeUnit.MILLISECONDS);
     }


### PR DESCRIPTION
[See](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ScheduledExecutorService.html#scheduleAtFixedRate(java.lang.Runnable,%20long,%20long,%20java.util.concurrent.TimeUnit))

**If any execution of the task encounters an exception, subsequent executions are suppressed.**

Before fix if unhandled exception occurs ScheduledExecutorService will not run further offset syncs but will not propagate error.
Thats why we did notice since October 7th that error occurred and backup sink task continued working without this thread.