### PR TITLE
TC-168/restore messages to point in time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ test {
 
 task runRestorationProcess(type: JavaExec) {
     if (project.hasProperty("configPath")) {
-        main = "de.azapps.kafkabackup.restore.topic.RestoreTopicsTask"
+        main = "de.azapps.kafkabackup.restore.topic.RestoreProcessTask"
         group = "Execution"
         classpath = sourceSets.main.runtimeClasspath
 

--- a/restore_config_examples/restore_topics.config
+++ b/restore_config_examples/restore_topics.config
@@ -1,12 +1,11 @@
-restore.shouldRestoreTopics=true
 aws.s3.bucketNameForConfig=config
 aws.s3.bucketNameForMessages=backup
 restore.time=2020-10-21T12:34:00+01:00
 kafka.bootstrap.servers=localhost:19092
+restore.topicsAllowList=topic-one
 aws.s3.region=eu-1-central
 aws.s3.endpoint=http://localhost:4572
 aws.s3.pathStyleAccessEnabled=true
-restore.hash=9e6ba976b91dc1c0ecfcbb89149e825f
-restore.topicList=topic-one,topic-two
+restore.hash=config1
 restore.dryRun=true
-restore.mode=TOPICS
+restore.mode=MESSAGES

--- a/src/main/java/de/azapps/kafkabackup/restore/RestoreFacade.java
+++ b/src/main/java/de/azapps/kafkabackup/restore/RestoreFacade.java
@@ -3,6 +3,8 @@ package de.azapps.kafkabackup.restore;
 import de.azapps.kafkabackup.common.AdminClientService;
 import de.azapps.kafkabackup.restore.common.RestoreArgsWrapper;
 import de.azapps.kafkabackup.restore.common.RestoreMode;
+import de.azapps.kafkabackup.restore.message.RestoreMessageProducer;
+import de.azapps.kafkabackup.restore.message.RestoreMessageS3Service;
 import de.azapps.kafkabackup.restore.message.RestoreMessageService;
 import de.azapps.kafkabackup.restore.topic.RestoreTopicService;
 import de.azapps.kafkabackup.storage.s3.AwsS3Service;
@@ -30,9 +32,11 @@ public class RestoreFacade {
       final AwsS3Service awsS3Service = new AwsS3Service(restoreArgsWrapper.getAwsRegion(),
           restoreArgsWrapper.getAwsEndpoint(),
           restoreArgsWrapper.getPathStyleAccessEnabled());
-      
+
+      RestoreMessageS3Service restoreMessageS3Service = new RestoreMessageS3Service(awsS3Service,
+          restoreArgsWrapper.getMessageBackupBucket());
       final RestoreMessageService restoreMessageService = new RestoreMessageService(awsS3Service, adminClientService,
-          restoreArgsWrapper.getRestoreMessagesMaxThreads());
+          restoreArgsWrapper.getRestoreMessagesMaxThreads(), restoreMessageS3Service);
       final RestoreTopicService restoreTopicService = new RestoreTopicService(adminClientService, awsS3Service);
       final RestoreOffsetService restoreOffsetService = new RestoreOffsetService();
 

--- a/src/main/java/de/azapps/kafkabackup/restore/common/RestoreArgsWrapper.java
+++ b/src/main/java/de/azapps/kafkabackup/restore/common/RestoreArgsWrapper.java
@@ -143,8 +143,9 @@ public class RestoreArgsWrapper {
     }
   }
 
-  public long getTimestampToRestore() {
-    return this.timeToRestore.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli();
+  public Optional<Long> getTimestampToRestore() {
+    return this.timeToRestore != null ?
+        Optional.of(this.timeToRestore.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()) : Optional.empty();
   }
 
   public Map<String, Object> adminConfig() {

--- a/src/main/java/de/azapps/kafkabackup/restore/common/RestoreArgsWrapper.java
+++ b/src/main/java/de/azapps/kafkabackup/restore/common/RestoreArgsWrapper.java
@@ -144,8 +144,8 @@ public class RestoreArgsWrapper {
   }
 
   public Optional<Long> getTimestampToRestore() {
-    return this.timeToRestore != null ?
-        Optional.of(this.timeToRestore.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()) : Optional.empty();
+    return Optional.ofNullable(this.timeToRestore)
+        .map(timeToRestore -> timeToRestore.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli());
   }
 
   public Map<String, Object> adminConfig() {

--- a/src/test/java/de/azapps/kafkabackup/helpers/TestRecordFactory.java
+++ b/src/test/java/de/azapps/kafkabackup/helpers/TestRecordFactory.java
@@ -41,6 +41,9 @@ public class TestRecordFactory {
 
   public static Record getRecordWithOffset(long offset) {
     return  new Record(topic, partition, keyBytes, valueBytes, offset, timestamp, timestampType, headers);
+  }
 
+  public static Record getRecordWithOffsetAndTimestamp(long offset, long timestamp) {
+    return  new Record(topic, partition, keyBytes, valueBytes, offset, timestamp, timestampType, headers);
   }
 }

--- a/src/test/java/de/azapps/kafkabackup/restore/message/PartitionMessageWriterWorkerTest.java
+++ b/src/test/java/de/azapps/kafkabackup/restore/message/PartitionMessageWriterWorkerTest.java
@@ -1,0 +1,111 @@
+package de.azapps.kafkabackup.restore.message;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import de.azapps.kafkabackup.common.TopicConfiguration;
+import de.azapps.kafkabackup.common.record.Record;
+import de.azapps.kafkabackup.helpers.TestRecordFactory;
+import de.azapps.kafkabackup.restore.common.RestoreArgsWrapper;
+import de.azapps.kafkabackup.restore.message.RestoreMessageService.TopicPartitionToRestore;
+import de.azapps.kafkabackup.storage.s3.AwsS3Service;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class PartitionMessageWriterWorkerTest {
+
+  private static final String TOPIC = "TOPIC_1";
+  private static final String FILE = "FILE_NAME";
+  private PartitionMessageWriterWorker sut;
+
+  LocalDateTime baseDate = LocalDateTime.of(2020, 11, 07, 11, 22, 33);
+
+  @Mock
+  private AwsS3Service awsS3Service;
+
+  @Mock
+  private RestoreArgsWrapper restoreArgsWrapper;
+
+  @Mock
+  private RestoreMessageS3Service restoreMessageS3Service;
+
+  @Mock
+  private RestoreMessageProducer restoreMessageProducer;
+
+  @BeforeEach
+  public void init() {
+    TopicPartitionToRestore topicPartitionToRestore = new TopicPartitionToRestore(new TopicConfiguration(TOPIC, 1, 1),
+        0);
+    sut = new PartitionMessageWriterWorker(topicPartitionToRestore, restoreArgsWrapper,
+        restoreMessageS3Service, restoreMessageProducer);
+
+    when(restoreMessageS3Service.getMessageBackupFileNames(eq(TOPIC), eq(0)))
+        .thenReturn(List.of(FILE));
+
+    when(restoreMessageS3Service.readBatchFile(eq(FILE))).thenReturn(prepareRecords());
+  }
+
+  @Test
+  public void shouldRestoreMessagesWhenTimestampToRestoreNotSet() {
+    // GIVEN
+    when(restoreArgsWrapper.getTimestampToRestore()).thenReturn(Optional.empty());
+
+    // when
+    sut.run();
+
+    // then
+    ArgumentCaptor<List<Record>> captor = ArgumentCaptor.forClass(List.class);
+    verify(restoreMessageProducer, times(1)).produceRecords(captor.capture());
+
+    assertEquals(3, captor.getValue().size());
+
+    assertTrue(captor.getValue().stream().anyMatch(record -> record.timestamp().equals(baseDate.minusHours(1).toInstant(ZoneOffset.UTC).toEpochMilli())));
+    assertTrue(captor.getValue().stream().anyMatch(record -> record.timestamp().equals(baseDate.toInstant(ZoneOffset.UTC).toEpochMilli())));
+    assertTrue(captor.getValue().stream().anyMatch(record -> record.timestamp().equals(baseDate.plusHours(1).toInstant(ZoneOffset.UTC).toEpochMilli())));
+  }
+
+  @Test
+  public void shouldNotRestoreNewerMessagesWhenTimestampToRestoreIsSet() {
+    // GIVEN
+    when(restoreArgsWrapper.getTimestampToRestore())
+        .thenReturn(Optional.of(baseDate.toInstant(ZoneOffset.UTC).toEpochMilli()));
+
+    // when
+    sut.run();
+
+    // then
+    ArgumentCaptor<List<Record>> captor = ArgumentCaptor.forClass(List.class);
+    verify(restoreMessageProducer, times(1)).produceRecords(captor.capture());
+
+    assertEquals(2, captor.getValue().size());
+
+    assertTrue(captor.getValue().stream().anyMatch(record -> record.timestamp().equals(baseDate.minusHours(1).toInstant(ZoneOffset.UTC).toEpochMilli())));
+    assertTrue(captor.getValue().stream().anyMatch(record -> record.timestamp().equals(baseDate.toInstant(ZoneOffset.UTC).toEpochMilli())));
+    assertFalse(captor.getValue().stream().anyMatch(record -> record.timestamp().equals(baseDate.plusHours(1).toInstant(ZoneOffset.UTC).toEpochMilli())));
+  }
+
+  private List<Record> prepareRecords() {
+    return List.of(
+        TestRecordFactory.getRecordWithOffsetAndTimestamp(0,
+            baseDate.minusHours(1).toInstant(ZoneOffset.UTC).toEpochMilli()),
+        TestRecordFactory
+            .getRecordWithOffsetAndTimestamp(1, baseDate.toInstant(ZoneOffset.UTC).toEpochMilli()),
+        TestRecordFactory.getRecordWithOffsetAndTimestamp(2,
+            baseDate.plusHours(1).toInstant(ZoneOffset.UTC).toEpochMilli())
+    );
+  }
+
+}

--- a/src/test/java/de/azapps/kafkabackup/restore/message/RestoreMessageProducerTest.java
+++ b/src/test/java/de/azapps/kafkabackup/restore/message/RestoreMessageProducerTest.java
@@ -3,7 +3,6 @@ package de.azapps.kafkabackup.restore.message;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import de.azapps.kafkabackup.common.TopicConfiguration;
 import de.azapps.kafkabackup.common.record.Record;
-import de.azapps.kafkabackup.common.record.RecordTest;
 import de.azapps.kafkabackup.helpers.TestRecordFactory;
 import de.azapps.kafkabackup.restore.common.RestoreArgsWrapper;
 import de.azapps.kafkabackup.restore.message.RestoreMessageService.TopicPartitionToRestore;


### PR DESCRIPTION
Open question:

Currently I am not stopping worker if any batch contains message newer than configured time to restore.
Maybe we could assume that next batches will contain only newer messages and not even bother with getting them from S3?
On the other hand they (timestamps) could be at least equal to few consecutive messages so maybe it's safer to check all of them