### PR TITLE
Tc 157/less producers more logs

### DIFF
--- a/restore_config_examples/restore_topics.config
+++ b/restore_config_examples/restore_topics.config
@@ -1,11 +1,12 @@
 aws.s3.bucketNameForConfig=config
 aws.s3.bucketNameForMessages=backup
 aws.s3.bucketNameForOffsets=offsets
-kafka.bootstrap.servers=localhost:29092
-aws.s3.region=eu-1-central
+kafka.bootstrap.servers=localhost:19092
+aws.s3.region=eu-central-1
 aws.s3.endpoint=http://localhost:4572
 aws.s3.pathStyleAccessEnabled=true
-restore.hash=b6beddb1cabe4889bfcfe6ae4638428f
-restore.dryRun=false
+restore.hash=4e695ea47c1a1966f512ba807e2b9830
+restore.dryRun=true
 restore.mode=MESSAGES,OFFSETS
 restore.topicsDenyList=(connect|__)(.*)
+restore.messages.maxThreads=2

--- a/src/main/java/de/azapps/kafkabackup/restore/message/PartitionMessageWriterWorker.java
+++ b/src/main/java/de/azapps/kafkabackup/restore/message/PartitionMessageWriterWorker.java
@@ -44,6 +44,8 @@ public class PartitionMessageWriterWorker implements Runnable {
 
       log.debug("Got {} files to restore.", filesToRestore.size());
 
+      restoreMessageProducer.initiateProducer(topicPartitionToRestore, restoreArgsWrapper);
+
       filesToRestore.forEach(this::restoreBackupFile);
 
       topicPartitionToRestore.setMessageRestorationStatus(MessageRestorationStatus.SUCCESS);

--- a/src/main/java/de/azapps/kafkabackup/restore/message/RestoreMessageProducer.java
+++ b/src/main/java/de/azapps/kafkabackup/restore/message/RestoreMessageProducer.java
@@ -42,7 +42,7 @@ public class RestoreMessageProducer {
       props.put("buffer.memory", 33554432);
       props.put("key.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
       props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
-      props.putAll(restoreArgsWrapper.adminConfig());
+      props.putAll(restoreArgsWrapper.saslConfig());
 
       props.put("transactional.id", "restore-transactional-id" + topicPartitionToRestore.getTopicPartitionId());
       props.putAll(restoreArgsWrapper.saslConfig());

--- a/src/main/java/de/azapps/kafkabackup/restore/message/RestoreMessageService.java
+++ b/src/main/java/de/azapps/kafkabackup/restore/message/RestoreMessageService.java
@@ -18,7 +18,6 @@ import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
@@ -110,7 +109,7 @@ public class RestoreMessageService {
           errorWorkers.size()));
 
       if (runningWorkers.size() > 0) {
-        infoBuilder.append("Running workers:");
+        infoBuilder.append("\nRunning workers:");
         runningWorkers.forEach(worker -> {
           final TopicPartitionToRestore topicPartitionToRestore = worker.getTopicPartitionToRestore();
           infoBuilder.append(String.format("\nWorker{Id:%s, Topic:%s, Partition: %s}", worker.getIdentifier(), topicPartitionToRestore.topicConfiguration.getTopicName(),
@@ -118,9 +117,9 @@ public class RestoreMessageService {
         });
       }
 
-    if (runningWorkers.size() > 0) {
+    if (errorWorkers.size() > 0) {
       infoBuilder.append("Error workers:");
-      runningWorkers.forEach(worker -> {
+      errorWorkers.forEach(worker -> {
         final TopicPartitionToRestore topicPartitionToRestore = worker.getTopicPartitionToRestore();
         infoBuilder.append(String.format("\nWorker{Id:%s, Topic:%s, Partition: %s}", worker.getIdentifier(), topicPartitionToRestore.topicConfiguration.getTopicName(),
             topicPartitionToRestore.getPartitionNumber()));

--- a/src/main/java/de/azapps/kafkabackup/restore/message/RestoreMessageService.java
+++ b/src/main/java/de/azapps/kafkabackup/restore/message/RestoreMessageService.java
@@ -9,6 +9,7 @@ import de.azapps.kafkabackup.restore.common.RestoreConfigurationHelper;
 import de.azapps.kafkabackup.restore.topic.RestoreTopicService;
 import de.azapps.kafkabackup.storage.s3.AwsS3Service;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +18,7 @@ import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
@@ -85,10 +87,47 @@ public class RestoreMessageService {
                 <= MessageRestorationStatus.RUNNING.ordinal());
   }
 
-  private Map<MessageRestorationStatus, List<PartitionMessageWriterWorker>> partitionMessageWriterWorkersInfo() {
-    return partitionWriters.values()
+  private String partitionMessageWriterWorkersInfo() {
+    Map<MessageRestorationStatus, List<PartitionMessageWriterWorker>> workersMap = partitionWriters.values()
         .stream()
         .collect(groupingBy(worker -> worker.getTopicPartitionToRestore().getMessageRestorationStatus()));
+
+    List<PartitionMessageWriterWorker> succeededWorkers = workersMap.getOrDefault(MessageRestorationStatus.SUCCESS,
+        Collections.emptyList());
+    List<PartitionMessageWriterWorker> runningWorkers = workersMap.getOrDefault(MessageRestorationStatus.RUNNING,
+        Collections.emptyList());
+    List<PartitionMessageWriterWorker> waitingWorkers = workersMap.getOrDefault(MessageRestorationStatus.WAITING,
+        Collections.emptyList());
+    List<PartitionMessageWriterWorker> errorWorkers = workersMap.getOrDefault(MessageRestorationStatus.ERROR,
+        Collections.emptyList());
+
+      final StringBuilder infoBuilder = new StringBuilder();
+          infoBuilder.append(String.format("Workers count:\nALL=%d\nSUCCESS=%d\nRUNNING=%d\nWAITING=%d\nERROR=%d",
+          partitionWriters.values().size(),
+          succeededWorkers.size(),
+          runningWorkers.size(),
+          waitingWorkers.size(),
+          errorWorkers.size()));
+
+      if (runningWorkers.size() > 0) {
+        infoBuilder.append("Running workers:");
+        runningWorkers.forEach(worker -> {
+          final TopicPartitionToRestore topicPartitionToRestore = worker.getTopicPartitionToRestore();
+          infoBuilder.append(String.format("\nWorker{Id:%s, Topic:%s, Partition: %s}", worker.getIdentifier(), topicPartitionToRestore.topicConfiguration.getTopicName(),
+              topicPartitionToRestore.getPartitionNumber()));
+        });
+      }
+
+    if (runningWorkers.size() > 0) {
+      infoBuilder.append("Error workers:");
+      runningWorkers.forEach(worker -> {
+        final TopicPartitionToRestore topicPartitionToRestore = worker.getTopicPartitionToRestore();
+        infoBuilder.append(String.format("\nWorker{Id:%s, Topic:%s, Partition: %s}", worker.getIdentifier(), topicPartitionToRestore.topicConfiguration.getTopicName(),
+            topicPartitionToRestore.getPartitionNumber()));
+      });
+    }
+
+      return infoBuilder.toString();
   }
 
   private List<TopicPartitionToRestore> getPartitionsToRestore(TopicsConfig config, List<String> topicsToRestore) {


### PR DESCRIPTION
Workers info log looks like this 
```
[main] INFO de.azapps.kafkabackup.restore.message.RestoreMessageService - Waiting for workers to finish. Partition message workers info: Workers count:
ALL=4
SUCCESS=3
RUNNING=1
WAITING=0
ERROR=0
Running workers:
Worker{Id:topic-two.1, Topic:topic-two, Partition: 1}
```

and we create as much workers as we have topic-partitions to restore but each initialises  it's own producer when it actually starts working - is started by thread pool executor