### PR TITLE
initialize offset map with 0->0

### DIFF
--- a/src/main/java/de/azapps/kafkabackup/restore/message/RestoreMessageProducer.java
+++ b/src/main/java/de/azapps/kafkabackup/restore/message/RestoreMessageProducer.java
@@ -101,12 +101,12 @@ public class RestoreMessageProducer {
           producerRecord.topic(),
           producerRecord.partition(),
           dryRunOffset);
-      topicPartitionToRestore.addRestoredMessageInfo(record.kafkaOffset(), record.key(), dryRunOffset);
+      topicPartitionToRestore.addRestoredMessageInfo(record.kafkaOffset(), dryRunOffset);
       dryRunOffset+=2;
       return null;
     }
     else {
-      topicPartitionToRestore.addRestoredMessageInfo(record.kafkaOffset(), record.key(), null);
+      topicPartitionToRestore.addRestoredMessageInfo(record.kafkaOffset(), null);
       return kafkaProducer.send(producerRecord);
     }
   }
@@ -138,7 +138,7 @@ public class RestoreMessageProducer {
       }
       else {
         RecordMetadata recordMetadata = recordFuturePair.getValue1().get();
-        topicPartitionToRestore.addRestoredMessageInfo(record.kafkaOffset(), record.key(), recordMetadata.offset());
+        topicPartitionToRestore.addRestoredMessageInfo(record.kafkaOffset(), recordMetadata.offset());
       }
     }
   }

--- a/src/main/java/de/azapps/kafkabackup/restore/message/RestoreMessageService.java
+++ b/src/main/java/de/azapps/kafkabackup/restore/message/RestoreMessageService.java
@@ -18,7 +18,6 @@ import java.util.concurrent.Executors;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.Data;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -171,7 +170,7 @@ public class RestoreMessageService {
     final TopicConfiguration topicConfiguration;
     final int partitionNumber;
     private MessageRestorationStatus messageRestorationStatus;
-    private Map<Long, RestoredMessageInfo> restoredMessageInfoMap;
+    private Map<Long, Long> restoredMessageInfoMap;
     private long maxOriginalOffset = -1L;
 
     public TopicPartitionToRestore(TopicConfiguration topicConfiguration, int partitionNumber) {
@@ -188,14 +187,8 @@ public class RestoreMessageService {
     }
 
     public void addRestoredMessageInfo(long originalOffset, Long newOffset) {
-      restoredMessageInfoMap.put(originalOffset, new RestoredMessageInfo(originalOffset, newOffset));
+      restoredMessageInfoMap.put(originalOffset,newOffset);
       maxOriginalOffset = Math.max(maxOriginalOffset, originalOffset);
     }
-  }
-
-  @Data
-  public static class RestoredMessageInfo {
-    private final long originalOffset;
-    private final Long newOffset;
   }
 }

--- a/src/main/java/de/azapps/kafkabackup/restore/message/RestoreMessageService.java
+++ b/src/main/java/de/azapps/kafkabackup/restore/message/RestoreMessageService.java
@@ -172,21 +172,23 @@ public class RestoreMessageService {
     final int partitionNumber;
     private MessageRestorationStatus messageRestorationStatus;
     private Map<Long, RestoredMessageInfo> restoredMessageInfoMap;
-    private long maxOriginalOffset = 0L;
+    private long maxOriginalOffset = -1L;
 
     public TopicPartitionToRestore(TopicConfiguration topicConfiguration, int partitionNumber) {
       this.topicConfiguration = topicConfiguration;
       this.partitionNumber = partitionNumber;
       this.messageRestorationStatus = MessageRestorationStatus.WAITING;
       this.restoredMessageInfoMap = new HashMap<>();
+      // Start out by always mapping offset 0 to offset 0 (for empty topics)
+      addRestoredMessageInfo(0L, 0L);
     }
 
     public String getTopicPartitionId() {
       return topicConfiguration.getTopicName() + "." + partitionNumber;
     }
 
-    public void addRestoredMessageInfo(long originalOffset, byte[] key, Long newOffset) {
-      restoredMessageInfoMap.put(originalOffset, new RestoredMessageInfo(originalOffset, key, newOffset));
+    public void addRestoredMessageInfo(long originalOffset, Long newOffset) {
+      restoredMessageInfoMap.put(originalOffset, new RestoredMessageInfo(originalOffset, newOffset));
       maxOriginalOffset = Math.max(maxOriginalOffset, originalOffset);
     }
   }
@@ -194,7 +196,6 @@ public class RestoreMessageService {
   @Data
   public static class RestoredMessageInfo {
     private final long originalOffset;
-    private final byte[] key;
     private final Long newOffset;
   }
 }


### PR DESCRIPTION
If a partition is empty, but a consumer group is committed to offset 0 (yes, that happens), we couldn't map that offset to restored cluster. This fixes that by always starting out with a 0->0 mapping